### PR TITLE
fix: keep emoji in UTF-8 sanitization

### DIFF
--- a/src/utils/sanitizeUTF8.test.ts
+++ b/src/utils/sanitizeUTF8.test.ts
@@ -20,4 +20,9 @@ describe('UTF-8 Sanitization', () => {
     const input = '你好，世界！';
     expect(sanitizeUTF8(input)).toBe('你好，世界！');
   });
+
+  it('should preserve emoji characters', () => {
+    const input = 'Hello😀World';
+    expect(sanitizeUTF8(input)).toBe('Hello😀World');
+  });
 });

--- a/src/utils/sanitizeUTF8.ts
+++ b/src/utils/sanitizeUTF8.ts
@@ -4,11 +4,27 @@
  */
 export const sanitizeUTF8 = (str: string) => {
   // 移除替换字符 (0xFFFD) 和其他非法字符
-  return (
-    str
-      .replaceAll('�', '') // 移除 Unicode 替换字符
-      // eslint-disable-next-line no-control-regex
-      .replaceAll(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F-\u009F]/g, '') // 移除控制字符
-      .replaceAll(/[\uD800-\uDFFF]/g, '')
-  ); // 移除未配对的代理项码点
+  return Array.from(str)
+    .filter((char) => {
+      // 移除 Unicode 替换字符
+      if (char === '�') return false;
+
+      const code = char.codePointAt(0)!;
+
+      // 移除控制字符
+      if (
+        (code >= 0x00 && code <= 0x08) ||
+        code === 0x0b ||
+        code === 0x0c ||
+        (code >= 0x0e && code <= 0x1f) ||
+        (code >= 0x7f && code <= 0x9f)
+      )
+        return false;
+
+      // 移除未配对的代理项码点
+      if (code >= 0xd800 && code <= 0xdfff) return false;
+
+      return true;
+    })
+    .join('');
 };


### PR DESCRIPTION
## Summary
- fix sanitizeUTF8 to avoid removing valid surrogate pairs such as emoji
- add tests to ensure emoji characters are preserved

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.10.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_b_68af58bfd518833391dd900d4b3b6746